### PR TITLE
fix deprecated get_cmap function from pyplot

### DIFF
--- a/towerpy/datavis/rad_interactive.py
+++ b/towerpy/datavis/rad_interactive.py
@@ -17,7 +17,7 @@ from matplotlib.widgets import RadioButtons, Slider
 from ..utils import radutilities as rut
 from ..base import TowerpyError
 
-warnings.filterwarnings("ignore", category=UserWarning)
+# warnings.filterwarnings("ignore", category=UserWarning)
 
 tpycm_ref = mpl.colormaps['tpylsc_ref']
 tpycm_plv = mpl.colormaps['tpylsc_pvars']

--- a/towerpy/datavis/tpy_cm.py
+++ b/towerpy/datavis/tpy_cm.py
@@ -4,7 +4,6 @@
 import warnings
 import numpy as np
 import matplotlib as mpl
-import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 from .tpy_colors import towerpy_colours
 
@@ -20,10 +19,10 @@ tpy_LSC = {cname: mcolors.LinearSegmentedColormap.from_list(cname, colrs)
 tpy_LC = {cname: mcolors.ListedColormap(colrs)
           for cname, colrs in towerpy_colours.items()}
 
-comb_tpycms = np.vstack((plt.cm.get_cmap(tpy_LSC['grey'])(np.linspace(0, 1,
-                                                                      64)),
-                         plt.cm.get_cmap(tpy_LSC['pvars'])(np.linspace(0, 1,
-                                                                       192))))
+comb_tpycms = np.vstack((mpl.colormaps.get_cmap(tpy_LSC['grey'])(np.linspace(0, 1,
+                                                                             64)),
+                         mpl.colormaps.get_cmap(tpy_LSC['pvars'])(np.linspace(0, 1,
+                                                                              192))))
 
 tpy_LSC['2slope'] = mcolors.LinearSegmentedColormap.from_list('2slope',
                                                               comb_tpycms)


### PR DESCRIPTION
# Description

The datavis module used a deprecated function from matplotlib, this is now fixed.
MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
  a = plt.cm.get_cmap(tpy_LSC['grey'])

