### PR TITLE
Fix minor bug in rd-qvps computation

### DIFF
--- a/towerpy/datavis/rad_display.py
+++ b/towerpy/datavis/rad_display.py
@@ -184,6 +184,9 @@ def plot_ppi(rad_georef, rad_params, rad_vars, var2plot=None, proj='rect',
         if '[dB]' in var2plot:
             cmaph = mpl.colormaps['tpylsc_2slope']
             cbtks_fmt = 1
+        if '[dBZ]' in var2plot:
+            cmaph = mpl.colormaps['tpylsc_ref']
+            cbtks_fmt = 1
         if '[deg/km]' in var2plot:
             cmaph = mpl.colormaps['tpylsc_2slope']
         if '[m/s]' in var2plot:
@@ -2421,7 +2424,7 @@ def plot_rdqvps(rscans_georef, rscans_params, tp_rdqvp, mlyr=None,
     for c, i in enumerate(tp_rdqvp.qvps_itp):
         for n, (a, (key, value)) in enumerate(zip(axd, i.items())):
             axd[a].plot(value, tp_rdqvp.georef['profiles_height [km]'],
-                        label=(f"{rscans_params[c]['elev_ang [deg]']}"
+                        label=(f"{rscans_params[c]['elev_ang [deg]']:.1f}"
                                + r"$^{\circ}$"), color=cmaph[c], ls='--')
             axd[a].set_xlabel(f'{key}', fontsize=fontsizelabels)
             if n == 0:


### PR DESCRIPTION
# Description

The w parameter in the rd-qvps module was incorrect. Values were too big for d-1<ri<=d
Fixes # (issue)
The w parameter is now computed correctly

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
