### PR TITLE
Refactor build_vp and build_qvp functions to improve height coordinate

### DIFF
--- a/towerpy/datavis/rad_display.py
+++ b/towerpy/datavis/rad_display.py
@@ -5132,7 +5132,7 @@ def plot_profiles(ds, stats=None, colours=False, mlyr_top=None, mlyr_btm=None,
 def plot_rdqvp(rdqvp, dss=None, all_desc=True, stats=None, mlyr_top=None,
                mlyr_btm=None, vars_bounds=None, unorm=None, cb_ext=None,
                ucmap=None, ylims=None, fig_size=None, spec_range=None,
-               fig_title=None, elev_cmap="Spectral"):
+               fig_title=None, elev_cmap="plasma_r"):
     """
     Plot a Range‑Defined Quasi‑Vertical Profile (RD‑QVP) and, optionally,
     the contributing QVPs.
@@ -5141,25 +5141,38 @@ def plot_rdqvp(rdqvp, dss=None, all_desc=True, stats=None, mlyr_top=None,
     ----------
     rdqvp : xarray.Dataset
         RD‑QVP dataset containing one or more variables defined on a 1D
-        ``height`` coordinate. May include:
-        - ``qvp_interp`` : interpolated QVPs with dims ``(elevation, variable, height)``
-        - ``scan_datetime`` : optional coordinate for scan start/end times
+        ``height`` coordinate. It may additionally contain:
+        
+        * ``qvp_interp`` : interpolated QVPs with dims
+          ``(elevation, variable, height)``.
+        * ``elevation_angle`` : elevation angles for each contributing QVP
+          (dimension ``elevation``), used for colouring individual QVPs.
+        * ``scan_datetime_unix_ns`` / ``scan_datetime_iso`` : optional
+          per‑elevation scan time information (dimension ``elevation``),
+          which may be used to construct the figure title via metadata
+          helpers.
     dss : list of xarray.Dataset or None, default None
-        Optional list of individual QVP scan datasets used to draw the
-        geometry panel (range–height curves).
+        Optional list of original single‑elevation PPI scan datasets used
+        to draw the geometry panel (range–height curves). Each dataset is
+        expected to contain at least:
+        
+        * ``range`` : range coordinate (convertible to km).
+        * ``beamc_height`` : beam‑height field with dims
+          ``(azimuth, range)`` or ``(range,)``.
     all_desc : bool, default True
-        If True, plot individual QVPs (from ``qvp_interp``) coloured by
-        elevation angle. If False, only the RD‑QVP is plotted.
+        If True and ``qvp_interp`` is present, plot individual QVPs
+        (from ``qvp_interp``) coloured by elevation angle. If False,
+        only the RD‑QVP profiles are plotted.
     stats : {'std', 'sem'} or None, default None
         If not None, shade each RD‑QVP profile using the corresponding
         statistic (``'std'`` or ``'sem'``) when the variable
         ``f"{stats}_{var}"`` exists in ``rdqvp``.
     mlyr_top : float or None, default None
-        Height (km) of the melting‑layer top. If provided, a horizontal
-        dashed line is drawn.
+        Height (in the same units as ``height``) of the melting‑layer top.
+        If provided, a horizontal dashed line is drawn.
     mlyr_btm : float or None, default None
-        Height (km) of the melting‑layer bottom. If provided, a horizontal
-        dashed line is drawn.
+        Height (in the same units as ``height``) of the melting‑layer bottom.
+        If provided, a horizontal dashed line is drawn.
     vars_bounds : dict or None, default None
         Optional per‑variable bounds overriding defaults from ``plot_params``.
         Keys are variable names; values are ``(vmin, vmax)``.
@@ -5181,8 +5194,9 @@ def plot_rdqvp(rdqvp, dss=None, all_desc=True, stats=None, mlyr_top=None,
     fig_title : str or None, default None
         Custom figure title. If None, a title is constructed from dataset
         metadata (profile type, radar name, and scan time).
-    elev_cmap : str, default 'Spectral'
-        Colormap used to colour individual QVPs by elevation angle.
+    elev_cmap : str, default 'plasma_r'
+        Colormap used to colour individual QVPs and geometry curves by
+        elevation index or elevation angle.
 
     Returns
     -------

--- a/towerpy/profs/polprofs.py
+++ b/towerpy/profs/polprofs.py
@@ -669,17 +669,18 @@ def build_vp(ds, inp_names=None, thresholds=None, valid_gates=0,
         agg = ds_masked.median(dim=names["azi"], skipna=True)
     agg = agg.where(count > valid_gates)
     # 7. Height coordinate
-    height = ds[names["beam_height"]].mean(dim=names["azi"])
-    height.attrs.setdefault("units",
-                            ds[names["beam_height"]].attrs.get("units", "km"))
-    agg = agg.assign_coords(height=height).swap_dims({names["rng"]: "height"})
+    bh = ds[names["beam_height"]]
+    height_1d = bh.mean(dim=names["azi"])  # dims: ('range',)
+    height_1d.attrs.setdefault("units", bh.attrs.get("units", "km"))
+    # use height_1d (dim='range') to replace the range dimension
+    agg = agg.assign_coords(height=height_1d).swap_dims({names["rng"]: "height"})
+    # reattach height as a coord over the new 'height' dim
+    agg = agg.assign_coords(height=("height", height_1d.values))
     if "range" in agg.coords:
         agg = agg.drop_vars("range")
     # 8. Assemble VP dataset
-    data_vars = {}
-    for canon, ds_name in inp_map.items():
-        data_vars[ds_name] = agg[ds_name]   # keep dataset name
-    vp = xr.Dataset(data_vars=data_vars, coords={"height": height})
+    data_vars = {ds_name: agg[ds_name] for ds_name in inp_map.values()}
+    vp = xr.Dataset(data_vars=data_vars, coords={"height": agg["height"]})
     # Clean up leftover range dimension/coordinate
     if "range" in vp.coords:
         vp = vp.drop_vars("range")
@@ -695,13 +696,13 @@ def build_vp(ds, inp_names=None, thresholds=None, valid_gates=0,
         min_ = min_.where(count > valid_gates)
         max_ = max_.where(count > valid_gates)
         sem = sem.where(count > valid_gates)
-        std = std.assign_coords(height=height).swap_dims(
+        std = std.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
-        min_ = min_.assign_coords(height=height).swap_dims(
+        min_ = min_.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
-        max_ = max_.assign_coords(height=height).swap_dims(
+        max_ = max_.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
-        sem = sem.assign_coords(height=height).swap_dims(
+        sem = sem.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
         if "range" in std.coords:
             std = std.drop_vars("range")
@@ -868,21 +869,20 @@ def build_qvp(ds, inp_names=None, beamwidth=None, thresholds="default",
     bh = ds[names["beam_height"]]
     # Allow 2D (azimuth, range) or 1D (range)
     if names['azi'] in bh.dims and names["rng"] in bh.dims:
-        height = bh.mean(dim=names['azi'])
+        height_1d = bh.mean(dim=names['azi'])
     else:
-        height = bh
+        height_1d = bh
     # IMPORTANT: keep dimension as "range"
-    height.attrs.setdefault("units", bh.attrs.get('units'))
-    agg = agg.assign_coords(height=height).swap_dims({names["rng"]: "height"})
+    height_1d.attrs.setdefault("units", bh.attrs.get('units'))
+    agg = agg.assign_coords(height=height_1d).swap_dims({names["rng"]: "height"})
+    # reattach height as a coord over the *new* 'height' dim
+    agg = agg.assign_coords(height=("height", height_1d.values))
     # Remove the old range coordinate from all variables
     if "range" in agg.coords:
         agg = agg.drop_vars("range")
     # 7. Assemble QVP dataset
-    data_vars = {}
-    for canon, ds_name in inp_map.items():
-        da = agg[ds_name]          # no rename
-        data_vars[ds_name] = da    # use dataset name
-    qvp = xr.Dataset(data_vars=data_vars, coords={"height": height})
+    data_vars = {ds_name: agg[ds_name] for ds_name in inp_map.values()}
+    qvp = xr.Dataset(data_vars=data_vars, coords={"height": agg["height"]})
     if "range" in qvp.coords:
         qvp = qvp.drop_vars("range")
     if "range" in qvp.dims:
@@ -897,13 +897,13 @@ def build_qvp(ds, inp_names=None, beamwidth=None, thresholds="default",
         min_ = min_.where(count > valid_gates)
         max_ = max_.where(count > valid_gates)
         sem = sem.where(count > valid_gates)
-        std = std.assign_coords(height=height).swap_dims(
+        std = std.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
-        min_ = min_.assign_coords(height=height).swap_dims(
+        min_ = min_.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
-        max_ = max_.assign_coords(height=height).swap_dims(
+        max_ = max_.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
-        sem = sem.assign_coords(height=height).swap_dims(
+        sem = sem.assign_coords(height=height_1d).swap_dims(
             {names["rng"]: "height"})
         if "range" in std.coords:
             std = std.drop_vars("range")
@@ -952,17 +952,17 @@ def build_qvp(ds, inp_names=None, beamwidth=None, thresholds="default",
         delta_h1 = xr.ones_like(h, dtype=float) * delta_h1
         delta_h1.attrs.update({"long_name": "vertical_resolution_range_gate",
                                "description": "Δh1 = Δr * sin(elev)",
-                               "units": height.attrs.get("units", "")})
+                               "units": height_1d.attrs.get("units", "")})
         # Δh2 = h * θ * cot(α)
         delta_h2 = h * bw_rad * (np.cos(elv_rad) / np.sin(elv_rad))
         delta_h2.attrs.update({"long_name": "vertical_resolution_beam_broadening",
                                "description": "Δh2 = h * beamwidth * cot(elev)",
-                               "units": height.attrs.get("units", "")})
+                               "units": height_1d.attrs.get("units", "")})
         # Δh = max(Δh1, Δh2)
         delta_h = xr.ufuncs.maximum(delta_h1, delta_h2)
         delta_h.attrs.update({"long_name": "effective_vertical_resolution",
                               "description": "Δh = max(Δh1, Δh2)",
-                              "units": height.attrs.get("units", "")})
+                              "units": height_1d.attrs.get("units", "")})
         # Attach to QVP dataset
         qvp["VRES"] = delta_h
         # Add to provenance


### PR DESCRIPTION
This PR fixes a inconsistency in the construction of the height coordinate in build_qvp and build_vp.
The previous implementation produced QVP/VP datasets where:
the dataset dimension was renamed from "range" to "height", but
the height coordinate itself still internally used the old "range" dimension.

This mismatch caused:

silent coordinate drops by xarray

broken or missing height coordinates

failures in downstream processing (especially build_rdqvp)

KeyError: 'height' and

ValueError: replacement dimension 'height' is not a 1D variable along the old dimension 'range'

This PR corrects the height‑coordinate construction so that:

height is always a 1D coordinate over the "height" dimension

no stale "range" dimension or coordinate survives

QVPs and VPs are internally consistent

RD‑QVP interpolation and concatenation work reliably

Changes Included
build_qvp
Corrected height coordinate construction

Reattached height over the new dimension

Ensured stats block mirrors the same logic

Ensured QVP assembly uses the fixed height

build_vp
Applied the same corrections as in build_qvp

Ensured stats block uses consistent height logic