### PR TITLE
Enhance metadata handling for cartesian and beam heights coordinates

### DIFF
--- a/towerpy/georad/georef_rdata.py
+++ b/towerpy/georad/georef_rdata.py
@@ -1,6 +1,7 @@
 """Towerpy: an open-source toolbox for processing polarimetric radar data."""
 
 import numpy as np
+from ..io import modeltp as mdtp
 from ..utils.unit_conversion import convert
 from ..utils.radutilities import get_attrval
 
@@ -207,7 +208,8 @@ def ppi_georef(rparams, georef=None, polarc_exist=True, elev=0.5,
         rng  = georef['range [m]']
     else:
         elev = np.deg2rad(np.full(rparams['nrays'], elev))
-        azim = np.deg2rad(np.linspace(0, 360, rparams['nrays'], endpoint=False))
+        azim = np.deg2rad(np.linspace(0, 360, rparams['nrays'],
+                                      endpoint=False))
         rng  = gate0 + np.arange(rparams['ngates'], dtype=float) * gateres
     
     elev_deg = np.rad2deg(elev)
@@ -218,8 +220,10 @@ def ppi_georef(rparams, georef=None, polarc_exist=True, elev=0.5,
     # Beam heights
     bhkm  = np.array([height_beamc(ray, rng_km) for ray in elev_deg])
     if bh_geom:
-        bbhkm = np.array([height_beamc(ray - bw/2, rng_km) for ray in elev_deg])
-        bthkm = np.array([height_beamc(ray + bw/2, rng_km) for ray in elev_deg])
+        bbhkm = np.array([height_beamc(ray - bw/2, rng_km)
+                          for ray in elev_deg])
+        bthkm = np.array([height_beamc(ray + bw/2, rng_km)
+                          for ray in elev_deg])
 
     # Cartesian conversion
     s = np.array([earth_arc_distance(ray, rng_km, bhkm[i])
@@ -288,6 +292,7 @@ def ppi_rectgeoref(sweep, radar_altitude=None, bh_geom=True, beamwidth=None):
     * Elevation, azimuth, and range are converted to radians/metres as needed.
     * Cartesian coordinates are returned in kilometres.
     """
+    sweep_vars_attrs_f = mdtp.sweep_vars_attrs_f
     # Build georef dict from dataset coords
     georef = {"azim [rad]": convert(sweep.coords["azimuth"], "rad").values,
               "elev [rad]": convert(sweep.coords["elevation"], "rad").values,
@@ -303,78 +308,25 @@ def ppi_rectgeoref(sweep, radar_altitude=None, bh_geom=True, beamwidth=None):
         sweep = sweep.assign_coords({
             "grid_rectx": (("azimuth", "range"), geogrid["grid_rectx"]),
             "grid_recty": (("azimuth", "range"), geogrid["grid_recty"]),
-            "beamc_height": (("azimuth", "range"), geogrid["beam_height [km]"]),
-            "beamb_height": (("azimuth", "range"), geogrid["beambottom_height [km]"]),
-            "beamt_height": (("azimuth", "range"), geogrid["beamtop_height [km]"]),
+            "beamc_height": (("azimuth", "range"),
+                             geogrid["beam_height [km]"]),
+            "beamb_height": (("azimuth", "range"),
+                             geogrid["beambottom_height [km]"]),
+            "beamt_height": (("azimuth", "range"),
+                             geogrid["beamtop_height [km]"]),
             })
     else:
         sweep = sweep.assign_coords({
             "grid_rectx": (("azimuth", "range"), geogrid["grid_rectx"]),
             "grid_recty": (("azimuth", "range"), geogrid["grid_recty"]),
-            "beamc_height": (("azimuth", "range"), geogrid["beam_height [km]"]),
+            "beamc_height": (("azimuth", "range"),
+                             geogrid["beam_height [km]"]),
             })
-    # Add metadata for Cartesian coordinates
-    sweep["grid_rectx"].attrs.update({
-        "units": "km",
-        "long_name": "radar-centric Cartesian x-coordinate",
-        "short_name": "XRECT",
-        "standard_name": "radar_cartesian_x_coordinate",
-        "description": ("Cartesian x-coordinate (km) derived from azimuth and"
-                        " range, with origin at the radar location."),
-        "coordinate_system": "radar_cartesian",
-        "reference_point": "radar_location",
-        "axis": "X"})
-    sweep["grid_recty"].attrs.update({
-        "units": "km",
-        "long_name": "radar-centric Cartesian y-coordinate",
-        "short_name": "YRECT",
-        "standard_name": "radar_cartesian_y_coordinate",
-        "description": ("Cartesian y-coordinate (km) derived from azimuth and"
-                        " range, with origin at the radar location."),
-        "coordinate_system": "radar_cartesian",
-        "reference_point": "radar_location",
-        "axis": "Y"})
-    # Base metadata for beam heights (radar-relative)
-    sweep["beamc_height"].attrs.update({
-        "units": "km",
-        "long_name": "beam centre height",
-        "short_name": "BEAM_HEIGHT",
-        "standard_name": "radar_beam_centre_height",
-        "description": ("Height of the radar beam centre (km), computed from "
-                        "elevation, range, and Earth curvature."),
-        "axis": "Z",
-        "coordinate_system": "radar_vertical",
-        "reference_point": "radar_location",
-        "height_reference": "radar",
-        })
-    if bh_geom:
-        sweep["beamb_height"].attrs.update({
-            "units": "km",
-            "long_name": "beam bottom height",
-            "short_name": "BEAM_BOTTOM_HEIGHT",
-            "standard_name": "radar_beam_bottom_height",
-            "description": ("Height of the lower edge of the radar beam (km),"
-                            " computed from elevation, range, beamwidth, and"
-                            " Earth curvature."),
-            "axis": "Z",
-            "coordinate_system": "radar_vertical",
-            "reference_point": "radar_location",
-            "height_reference": "radar",
-        })
-        sweep["beamt_height"].attrs.update({
-            "units": "km",
-            "long_name": "beam top height",
-            "short_name": "BEAM_TOP_HEIGHT",
-            "standard_name": "radar_beam_top_height",
-            "description": ("Height of the upper edge of the radar beam (km),"
-                            " computed from elevation, range, beamwidth, and"
-                            " Earth curvature."),
-            "axis": "Z",
-            "coordinate_system": "radar_vertical",
-            "reference_point": "radar_location",
-            "height_reference": "radar",
-        })
-    # Apply altitude offset
+    # Add metadata for coordinates from modeltp
+    for name, attrs in sweep_vars_attrs_f.items():
+        if name in sweep:
+            sweep[name].attrs.update(attrs)
+    # Apply altitude offset (AMSL)
     if radar_altitude is not None:
         sweep["beamc_height"] = sweep["beamc_height"] + radar_altitude
         if bh_geom:

--- a/towerpy/io/modeltp.py
+++ b/towerpy/io/modeltp.py
@@ -14,6 +14,65 @@ variable names realted to function outputs.
 
 sweep_vars_attrs_xrd = model.sweep_vars_mapping
 
+sweep_vars_attrs_rect = {
+    "grid_rectx": {"standard_name": "radar_cartesian_x_coordinate",
+                   "long_name": "radar-centric Cartesian x-coordinate",
+                   "short_name": "XRECT",
+                   "units": "km",
+                   "description": ("Cartesian x-coordinate (km) derived from "
+                                   "azimuth and range, with origin at the "
+                                   "radar location."),
+                   "axis": "X",
+                   "coordinate_system": "radar_cartesian",
+                   "reference_point": "radar_location"},
+    "grid_recty": {"standard_name": "radar_cartesian_y_coordinate",
+                   "long_name": "radar-centric Cartesian y-coordinate",
+                   "short_name": "YRECT",
+                   "units": "km",
+                   "description": ("Cartesian y-coordinate (km) derived from"
+                                   " azimuth and range, with origin at the "
+                                   "radar location."),
+                   "axis": "Y",
+                   "coordinate_system": "radar_cartesian",
+                   "reference_point": "radar_location"}
+    }
+
+sweep_vars_attrs_hbeam = {
+    "beamc_height": {"standard_name": "radar_beam_centre_height",
+                     "long_name": "beam centre height",
+                     "short_name": "BEAM_HEIGHT",
+                     "units": "km",
+                     "description": ("Height of the radar beam centre (km), "
+                                     "computed from elevation, range, and "
+                                     "Earth curvature."),
+                     "axis": "Z",
+                     "coordinate_system": "radar_vertical",
+                     "reference_point": "radar_location",
+                     "height_reference": "radar"},
+    "beamb_height": {"standard_name": "radar_beam_bottom_height",
+                     "long_name": "beam bottom height",
+                     "short_name": "BEAM_BOTTOM_HEIGHT",
+                     "units": "km",
+                     "description": ("Height of the lower edge of the radar "
+                                     "beam (km), computed from elevation, "
+                                     "range, beamwidth, and Earth curvature."),
+                     "axis": "Z",
+                     "coordinate_system": "radar_vertical",
+                     "reference_point": "radar_location",
+                     "height_reference": "radar"},
+    "beamt_height": {"standard_name": "radar_beam_top_height",
+                     "long_name": "beam top height",
+                     "short_name": "BEAM_TOP_HEIGHT",
+                     "units": "km",
+                     "description": ("Height of the upper edge of the radar "
+                                     "beam (km), computed from elevation, "
+                                     "range, beamwidth, and Earth curvature."),
+                     "axis": "Z",
+                     "coordinate_system": "radar_vertical",
+                     "reference_point": "radar_location",
+                     "height_reference": "radar"},
+    }
+
 sweep_vars_attrs_ukmo = {
     'CI': {'standard_name': 'clutter_indicator',
            'long_name': 'pulse-to-pulse variation of power',
@@ -41,27 +100,31 @@ sweep_vars_attrs_clc = {
     }
 
 sweep_vars_attrs_mlyr = {
-    "MLYRTOP": {
-        "standard_name": "mlyr_top",
-        "long_name": "melting-layer top height",
-        "short_name": "MLYRTOP",
-        "units": "km",
-        "description": "Height of the upper boundary of the melting layer",
-        },
-    "MLYRBTM": {
-        "standard_name": "mlyr_bottom",
-        "long_name": "melting-layer bottom height",
-        "short_name": "MLYRBTM",
-        "units": "km",
-        "description": "Height of the lower boundary of the melting layer",
-        },
-    "MLYRTHK": {
-        "standard_name": "mlyr_thickness",
-        "long_name": "melting-layer thickness",
-        "short_name": "MLYRTHK",
-        "units": "km",
-        "description": "Vertical thickness of the melting layer"
-        }
+    "MLYRTOP": {"standard_name": "mlyr_top",
+                "long_name": "melting-layer top height",
+                "short_name": "MLYRTOP",
+                "units": "km",
+                "description": ("Height of the upper boundary of the melting "
+                                "layer"),
+                "axis": "Z",
+                "coordinate_system": "radar_vertical",
+                "reference_point": "radar_location",
+                "height_reference": "radar"},
+    "MLYRBTM": {"standard_name": "mlyr_bottom",
+                "long_name": "melting-layer bottom height",
+                "short_name": "MLYRBTM",
+                "units": "km",
+                "description": ("Height of the lower boundary of the melting "
+                                "layer"),
+                "axis": "Z",
+                "coordinate_system": "radar_vertical",
+                "reference_point": "radar_location",
+                "height_reference": "radar"},
+    "MLYRTHK": {"standard_name": "mlyr_thickness",
+                "long_name": "melting-layer thickness",
+                "short_name": "MLYRTHK",
+                "units": "km",
+                "description": "Vertical thickness of the melting layer"}
     }
 
 sweep_vars_attrs_mlpcp = {
@@ -111,40 +174,40 @@ sweep_vars_attrs_qpe = {
                   "units": "mm h-1"},
     "RAIN_ACCUM": {"standard_name": "rain_accumulation",
                    "long_name": "rainfall_amount",
-                   'short_name': 'MLPCLASS',
+                   'short_name': 'RAINACC',
                    "units": "mm"},
     }
 
 sweep_vars_attrs_profs = {
-    "GRAD_VRADV": {
-        "standard_name": "vertical_gradient_of_radial_velocity",
-        "long_name": "Vertical gradient of Doppler radial velocity",
-        "short_name": "GRAD_VRADV",
-        "units": "∂V/∂h"},
-    'BIN_CLASS': {
-        "standard_name": "precipitation_classification_in_height_bins",
-        "long_name": "Per-height-bin precipitation classification",
-        "short_name": "BIN_CLASS",
-        "units": "flags [6]",
-        "flags": {"no_rain": 0, "light_rain": 1, "modrt_rain": 2,
-                  "heavy_rain": 3, "mixed_pcpn": 4, "solid_pcpn": 5}},
-    'PROF_TYPE': {
-        "standard_name": "precipitation_type_of_profile",
-        "long_name": "Profile precipitation type (0–6 scheme)",
-        "short_name": "PROF_TYPE",
-        "units": "flags [7]",
-        "flags": {"NR": 0, "LR [STR]": 1, "MR [STR]": 2, "HR [STR]": 3,
-                  "LR [CNV]": 4, "MR [CNV]": 5, "HR [CNV]": 6}},
-    'PCP_TYPE': {
-        "standard_name": "scalar_precipitation_type_of_profile",
-        "long_name": "Scalar precipitation type",
-        "short_name": "PCP_TYPE",
-        "units": "flags [7]",
-        "flags": {"NR": 0, "LR [STR]": 1, "MR [STR]": 2, "HR [STR]": 3,
-                  "LR [CNV]": 4, "MR [CNV]": 5, "HR [CNV]": 6}}
+    "GRAD_VRADV": {"standard_name": "vertical_gradient_of_radial_velocity",
+                   "long_name": "Vertical gradient of Doppler radial velocity",
+                   "short_name": "GRAD_VRADV",
+                   "units": "∂V/∂h"},
+    'BIN_CLASS': {"standard_name": "precipitation_classification_in_height_bins",
+                  "long_name": "Per-height-bin precipitation classification",
+                  "short_name": "BIN_CLASS",
+                  "units": "flags [6]",
+                  "flags": {"no_rain": 0, "light_rain": 1, "modrt_rain": 2,
+                            "heavy_rain": 3, "mixed_pcpn": 4, "solid_pcpn": 5}},
+    'PROF_TYPE': {"standard_name": "precipitation_type_of_profile",
+                  "long_name": "Profile precipitation type (0–6 scheme)",
+                  "short_name": "PROF_TYPE",
+                  "units": "flags [7]",
+                  "flags": {"NR": 0, "LR [STR]": 1, "MR [STR]": 2,
+                            "HR [STR]": 3, "LR [CNV]": 4, "MR [CNV]": 5,
+                            "HR [CNV]": 6}},
+    'PCP_TYPE': {"standard_name": "scalar_precipitation_type_of_profile",
+                 "long_name": "Scalar precipitation type",
+                 "short_name": "PCP_TYPE",
+                 "units": "flags [7]",
+                 "flags": {"NR": 0, "LR [STR]": 1, "MR [STR]": 2,
+                           "HR [STR]": 3, "LR [CNV]": 4, "MR [CNV]": 5,
+                           "HR [CNV]": 6}}
     }
 
 sweep_vars_attrs_f = (sweep_vars_attrs_xrd     |
+                      sweep_vars_attrs_rect    |
+                      sweep_vars_attrs_hbeam   |
                       sweep_vars_attrs_ukmo    |
                       sweep_vars_attrs_snr     |
                       sweep_vars_attrs_clc     |

--- a/towerpy/io/ukmo.py
+++ b/towerpy/io/ukmo.py
@@ -829,7 +829,8 @@ def read_ukmo_ppi_binary(file_name, site_name, get_polvar='all',
             # 'starttime': np.nan,
             }
         }
-    rswp_metadata['how']['frequency'] = (sc.c / (rswp_metadata['how']['wavelength'] * 1e-2) / 1e9)
+    rswp_metadata['how']['frequency'] = (
+        sc.c / (rswp_metadata['how']['wavelength'] * 1e-2) / 1e9)
     scandt_av, scandt_avpy = scan_midtime(sweep['time'].values)
     ts_ns = int(scandt_av.astype("datetime64[ns]").astype("int"))
     rswp_metadata['what']['sweep_avrg_datetime_unix_ns'] = ts_ns


### PR DESCRIPTION
# PR: Refactor `georef_rdata` and `modeltp` to unify and enhance metadata handling for Cartesian coordinates and beam‑height variables

## Summary

This PR refactors the metadata architecture for sweep‑level georeferencing in towerpy.  
The main goals are:

- Establish `modeltp` as the single source of truth for radar‑relative metadata  
- Remove duplicated metadata definitions inside `georef_rdata.ppi_rectgeoref`  
- Ensure consistent CF‑compliant metadata for Cartesian coordinates and beam‑height variables  
- Apply AMSL overrides only when altitude is added, in a clean and predictable way  

This results in a cleaner, more maintainable, and more extensible metadata pipeline across all towerpy workflows .

## Motivation

Before this PR:

- `ppi_rectgeoref()` hard‑coded metadata for:
  - `grid_rectx`, `grid_recty`
  - `beamc_height`, `beamb_height`, `beamt_height`
- `modeltp` did not define these variables, so metadata was duplicated across modules
- Adding new beam variables (e.g., `beamb_height`, `beamt_height`) required updating multiple modules

This PR resolves these issues by centralizing metadata definitions and simplifying georeferencing logic.

## Key Architectural Changes

### 1. `modeltp` now defines canonical radar‑relative metadata

New metadata blocks added:

- `sweep_vars_attrs_rect`  
  - `grid_rectx`, `grid_recty`  
  - radar‑centric Cartesian coordinates  
  - CF‑consistent (`radar_cartesian_x_coordinate`, etc.)

- `sweep_vars_attrs_hbeam`  
  - `beamc_height`, `beamb_height`, `beamt_height`  
  - radar‑relative beam geometry  
  - CF‑consistent (`radar_beam_*_height`)

These are merged into `sweep_vars_attrs_f`, making them available to all sweep‑level datasets.

### 2. `ppi_rectgeoref()` no longer hard‑codes metadata

The function now:

- computes georeferenced coordinates  
- assigns them to the dataset  
- applies metadata from `modeltp`  
- applies AMSL overrides only when altitude is added

This removes duplication and ensures consistency.

### 3. AMSL override logic is preserved and isolated

When `radar_altitude` is provided:

- beam heights are offset by altitude  
- metadata is updated to:
  - `reference_point = mean_sea_level`
  - `height_reference = amsl`
  - `coordinate_system = earth_vertical`
  - `standard_name = height`

This matches CF conventions and keeps radar‑relative vs AMSL semantics cleanly separated.

## Code Changes

### `modeltp.py`

- Added `sweep_vars_attrs_rect`  
- Added `sweep_vars_attrs_hbeam`  
- Updated `sweep_vars_attrs_f` merge order  
- Fixed minor metadata inconsistencies (e.g., `RAIN_ACCUM.short_name`)

### `georef_rdata.ppi_rectgeoref()`

- Removed duplicated metadata blocks  
- Added metadata application via `sweep_vars_attrs_f`  
- Preserved AMSL override logic  
- Cleaned up redundant loops

## Benefits

- Single source of truth for metadata  
- No duplication across modules  
- CF‑consistent metadata for all beam and Cartesian variables  
- Extensible: adding new beam variables requires updating only `modeltp`  
- Predictable AMSL semantics  
- Improved maintainability and readability

## Backward Compatibility

Fully backward‑compatible:

- Radar‑relative metadata remains unchanged  
- AMSL override logic is preserved  
- No API changes

## Next Steps (optional)

- Extend metadata definitions for projected coordinates (`grid_utmx`, `grid_utmy`)  
- Add CF metadata for WGS84 lon/lat grids  
- Consider adding provenance entries for AMSL conversion
